### PR TITLE
Avoid bouncing of image in original form

### DIFF
--- a/src/libraries/ViewTransformer/index.js
+++ b/src/libraries/ViewTransformer/index.js
@@ -188,7 +188,7 @@ export default class ViewTransformer extends React.Component {
             dy = d.dy;
         }
 
-        if (!this.props.enableTranslate) {
+        if (!this.props.enableTranslate || this.state.scale === 1) {
             dx = dy = 0;
         }
 


### PR DESCRIPTION
This ensures that translation does not take when the image is in its original size.